### PR TITLE
fix: able to use *.svg?url files within Image

### DIFF
--- a/svg.d.ts
+++ b/svg.d.ts
@@ -1,0 +1,7 @@
+/** svg imports with a ?url suffix can be used as the src value in Image components */
+declare module "*.svg?url" {
+  import { StaticImport } from "next/image";
+
+  const defaultExport: StaticImport | string;
+  export default defaultExport;
+}


### PR DESCRIPTION
Example of usage which works correct:

```
import Bell from '@/assets/icons/bell.svg';
import BellUrl from '@/assets/icons/bell.svg?url';
import Image from 'next/image';

export const ExpandBtn = () => {
  return (
    <>
      <Image alt={'bell'} src={BellUrl} />
      <Bell />
    </>
  );
};
```
