### PR TITLE
fix: add controlledTextField

### DIFF
--- a/features/accounts/edit/profile-form/profile-form.tsx
+++ b/features/accounts/edit/profile-form/profile-form.tsx
@@ -82,7 +82,6 @@ export const ProfileForm: FC = () => {
               format={'DD.MM.YYYY'}
               label={'Birth Date'}
               onChange={date => {
-                // Temporary solution until there is no logic to validate user manual input
                 if (date instanceof DateObject) {
                   onChange(date.valueOf());
                 } else {


### PR DESCRIPTION
add controlledTextField. Control and TextField rebased with controlledTextField in EditProfile.
But

`  const {
    field,
    fieldState: { error },
  } = useController({
    control: props.control,
    name: props.name,
  });`
there's something wrong with the typing, .
Can you take a look?