### PR TITLE
fix: registration confirmation behavior

### DIFF
--- a/pages/confirm-registration/confirm-registration.module.scss
+++ b/pages/confirm-registration/confirm-registration.module.scss
@@ -1,0 +1,15 @@
+@use '../../styles/mixins' as *;
+@use '../../styles/helpers' as *;
+
+.outerContainer {
+  margin-top: 60px;
+  margin-left: 220px;
+}
+
+.innerContainer {
+  @include flex($justify: null, $direction: column);
+
+  gap: rem(16);
+  max-width: 300px;
+  margin-inline: auto;
+}

--- a/pages/confirm-registration/index.tsx
+++ b/pages/confirm-registration/index.tsx
@@ -1,30 +1,56 @@
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 
 import { useConfirmCodeMutation } from '@/shared/api/auth-api';
+import { Button, Typography } from '@/shared/ui';
 import { HeadMeta } from '@/widgets/HeadMeta/HeadMeta';
 import { getLayout } from '@/widgets/Layout/Layout';
-import { useRouter, useSearchParams } from 'next/navigation';
+import Link from 'next/link';
+import { useRouter } from 'next/router';
 
-function ConfirmRegistration() {
-  const searchParams = useSearchParams();
-  const userId = searchParams.get('userId');
-  const code = searchParams.get('code');
+import s from './confirm-registration.module.scss';
+
+export const ConfirmRegistration = () => {
   const router = useRouter();
-  const [confirmCode] = useConfirmCodeMutation();
+  const [confirmCode, { data: response }] = useConfirmCodeMutation();
+  const { query } = router;
 
   useEffect(() => {
-    if (code && userId) {
-      confirmCode({ code, userId });
-      router.push('/email-confirmed');
+    if (query.code) {
+      confirmCode({ code: query.code as string });
     }
-  }, [confirmCode, router, code, userId]);
+  }, [confirmCode, query]);
+
+  /**
+   * render the desired UI depending on the `confirmCode` response.
+   * - If all was successful, then show [this UI]{@link (https://www.figma.com/file/M7753HAzy0tm9rQWyRBrnI/Inctagram?type=design&node-id=301-5874&mode=design&t=pZd1HNpBuoy77ApL-4)}
+   * - If the confirmation code has expired, show [this UI]{@link (https://www.figma.com/file/M7753HAzy0tm9rQWyRBrnI/Inctagram?type=design&node-id=301-6009&mode=design&t=pZd1HNpBuoy77ApL-4)}
+   * - If the user tries to reuse the already confirmed code, then write something like "Invalid confirmation code. Please register for the confirmation code.  [/sign-up]{@link (../sign-up/index.tsx)}". __This UI is not in figma! You have to create it yourself__.
+   */
+  const success = response?.data;
 
   return (
     <>
       <HeadMeta title={'Confirm Registration'} />
+      <div className={s.outerContainer}>
+        <div className={s.innerContainer}>
+          {success ? (
+            <>
+              <Typography.H1>Congratulations!</Typography.H1>
+              <Typography.Regular16>Your email has been confirmed</Typography.Regular16>
+              <Button as={'span'}>
+                <Link href={'/sign-up'}>sign up</Link>
+              </Button>
+            </>
+          ) : (
+            <Typography.H1 style={{ textAlign: 'center' }}>
+              `code` search param wasn&apos;t provided or expired.
+            </Typography.H1>
+          )}
+        </div>
+      </div>
     </>
   );
-}
+};
 
 ConfirmRegistration.getLayout = getLayout;
 export default ConfirmRegistration;

--- a/shared/api/auth-api.ts
+++ b/shared/api/auth-api.ts
@@ -1,6 +1,7 @@
 import type {
   ChangePasswordRequestType,
-  ConfirmCodeRequestType,
+  ConfirmCodeRequestData,
+  ConfirmCodeResponse,
   LoginRequestData,
   LoginResponse,
   LogoutResponse,
@@ -25,7 +26,7 @@ export const authApi = baseApi.injectEndpoints({
         };
       },
     }),
-    confirmCode: builder.mutation<void, ConfirmCodeRequestType>({
+    confirmCode: builder.mutation<ConfirmCodeResponse, ConfirmCodeRequestData>({
       query: params => {
         return {
           body: params,

--- a/shared/types/auth.types.ts
+++ b/shared/types/auth.types.ts
@@ -22,10 +22,10 @@ export type ChangePasswordRequestType = {
   password: string;
   userId: string;
 };
-export type ConfirmCodeRequestType = {
-  code: string;
-  userId: string;
-};
+export type ConfirmCodeRequestData = { code: string };
+
+export type ConfirmCodeResponse = AppResponse<null | true>;
+
 export type PasswordRecoveryRequestType = {
   email: string;
 };


### PR DESCRIPTION
Make the email confirmation process available with a code received via email to the new registered user.
All related logic is executed on the `/confirm-registration` page.