### PR TITLE
useIntersectionObserver

### DIFF
--- a/shared/hooks/useIntersectionObserver.ts
+++ b/shared/hooks/useIntersectionObserver.ts
@@ -1,0 +1,35 @@
+import { useCallback, useEffect, useRef } from 'react';
+
+type Props = {
+  callback: () => void;
+  options?: IntersectionObserverInit;
+};
+
+export const useIntersectionObserver = ({ callback, options }: Props) => {
+  const targetRef = useRef<HTMLDivElement | null>(null);
+
+  const handleObserver = useCallback(
+    (entries: IntersectionObserverEntry[]) => {
+      if (entries[0].isIntersecting) {
+        callback();
+      }
+    },
+    [callback]
+  );
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(handleObserver, options);
+
+    if (targetRef.current) {
+      observer.observe(targetRef.current);
+    }
+
+    return () => {
+      if (targetRef.current) {
+        observer.unobserve(targetRef.current);
+      }
+    };
+  }, [handleObserver, options]);
+
+  return targetRef;
+};


### PR DESCRIPTION
**A custom React hook that triggers a callback when a target element intersects with the viewport.**

### Parameters
- **callback (function)**: The function to be called when the target element intersects with the viewport.
- **options (IntersectionObserverInit, optional)**: Options to customize the behavior of the IntersectionObserver.

### Returns
- **targetRef (ref)**: A ref to be attached to the target element to be observed.